### PR TITLE
Introduced HPC into relevant parts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ add_library(symphony SHARED
 
 target_include_directories(symphony PUBLIC include)
 
+# add openmp
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(symphony PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
 enable_testing()
 
 add_subdirectory(tests)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <vector>
 #include <functional>
+#include <omp.h>
 
 
 Search *create_search(SearchAlgorithmIndex search_algorithm_index, Problem *problem) {
@@ -60,6 +61,7 @@ std::shared_ptr<Node> BreadthFirstSearch::search() {
         if (problem->goal_test(state)) {
             return node;
         }
+        #pragma omp parallel for shared(frontier) schedule(dynamic) if (frontier.size() > 1000)
         for (const auto &action : problem->actions(node->state)) {
             auto child = std::make_shared<Node>(
                 std::shared_ptr<Node>(node),

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "definitions.h"
 #include "search.h"
+#include <omp.h>
 
 class TestState : public State {
 public:
@@ -18,7 +19,7 @@ public:
     }
     bool goal_test(State *state) override {
         auto *test_state = dynamic_cast<TestState *>(state);
-        return test_state->value == 10;
+        return test_state->value == 10010;
     }
     std::vector<std::shared_ptr<Action>> actions(std::shared_ptr<State> state) override {
         auto test_state = std::dynamic_pointer_cast<TestState>(state);
@@ -28,7 +29,7 @@ public:
     }
     double heuristic(State *state) override {
         auto *test_state = dynamic_cast<TestState *>(state);
-        return 10 - test_state->value;
+        return 10010 - test_state->value;
     }
 };
 
@@ -40,18 +41,24 @@ TEST(Definitions, State) {
 TEST(Search, AStarSearch) {
     TestProblem problem;
     Search *search = create_search(SearchAlgorithmIndex::A_STAR, &problem);
+    double start = omp_get_wtime();
     std::shared_ptr<Node> node = search->search();
+    double end = omp_get_wtime();
+    std::cout << "Time: " << end - start << std::endl;
     ASSERT_NE(node, nullptr);
-    EXPECT_EQ(dynamic_cast<TestState *>(node->state.get())->value, 10);
+    EXPECT_EQ(dynamic_cast<TestState *>(node->state.get())->value, 10010);
     delete search;
 }
 
 TEST(Search, BreadthFirstSearch) {
     TestProblem problem;
     Search *search = create_search(SearchAlgorithmIndex::BREADTH_FIRST_SEARCH, &problem);
+    double start = omp_get_wtime();
     std::shared_ptr<Node> node = search->search();
+    double end = omp_get_wtime();
+    std::cout << "Time: " << end - start << std::endl;
     ASSERT_NE(node, nullptr);
-    EXPECT_EQ(dynamic_cast<TestState *>(node->state.get())->value, 10);
+    EXPECT_EQ(dynamic_cast<TestState *>(node->state.get())->value, 10010);
     delete search;
 }
 
@@ -60,7 +67,7 @@ TEST(Search, BeamSearch) {
     Search *search = create_search(SearchAlgorithmIndex::BEAM_SEARCH, &problem);
     std::shared_ptr<Node> node = search->search();
     ASSERT_NE(node, nullptr);
-    EXPECT_EQ(dynamic_cast<TestState *>(node->state.get())->value, 10);
+    EXPECT_EQ(dynamic_cast<TestState *>(node->state.get())->value, 10010);
     delete search;
 }
 


### PR DESCRIPTION
This pull request introduces OpenMP parallelism to the project, modifies the goal test and heuristic values in the test suite, and adds timing measurements to the search tests. The most important changes include adding OpenMP support, updating the goal test and heuristic values, and measuring execution time in tests.

### Parallelism and Performance Improvements:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR17-R22): Added OpenMP support by finding the OpenMP package and linking it to the `symphony` target if found.
* [`src/search.cpp`](diffhunk://#diff-da923b7afa45cab7add143c4705b54142e46b2afe9a2627d5fa3b3474bdc8aecR10): Included the OpenMP header and added a parallel for loop with dynamic scheduling for the breadth-first search algorithm. [[1]](diffhunk://#diff-da923b7afa45cab7add143c4705b54142e46b2afe9a2627d5fa3b3474bdc8aecR10) [[2]](diffhunk://#diff-da923b7afa45cab7add143c4705b54142e46b2afe9a2627d5fa3b3474bdc8aecR64)

### Test Suite Modifications:

* [`tests/tests.cpp`](diffhunk://#diff-2a7dd0df8cbb200533858c597144a48308d3b4c764da7d75c4fef4bd239240abL21-R22): Updated the goal test and heuristic values in the `TestProblem` class to use 10010 instead of 10. [[1]](diffhunk://#diff-2a7dd0df8cbb200533858c597144a48308d3b4c764da7d75c4fef4bd239240abL21-R22) [[2]](diffhunk://#diff-2a7dd0df8cbb200533858c597144a48308d3b4c764da7d75c4fef4bd239240abL31-R32)
* [`tests/tests.cpp`](diffhunk://#diff-2a7dd0df8cbb200533858c597144a48308d3b4c764da7d75c4fef4bd239240abR44-R61): Added timing measurements using `omp_get_wtime()` to the A* search and breadth-first search tests to measure and print the execution time.

These changes aim to enhance the performance of the search algorithms through parallelism and provide more accurate test results with updated values and performance metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OpenMP support for parallel processing in the project
  - Introduced performance measurement capabilities for search algorithms

- **Performance Improvements**
  - Enabled parallel node expansion in Breadth-First Search
  - Added execution time tracking for search algorithms

- **Test Updates**
  - Modified test problem logic and goal state conditions
  - Updated test cases to reflect new expected values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->